### PR TITLE
remove signal SIGSTKFLT.

### DIFF
--- a/bfe_server/bfe_server.go
+++ b/bfe_server/bfe_server.go
@@ -326,7 +326,6 @@ func (srv *BfeServer) InitSignalTable() {
 	srv.SignalTable.Register(syscall.SIGILL, signal_table.IgnoreHandler)
 	srv.SignalTable.Register(syscall.SIGTRAP, signal_table.IgnoreHandler)
 	srv.SignalTable.Register(syscall.SIGABRT, signal_table.IgnoreHandler)
-	srv.SignalTable.Register(syscall.SIGSTKFLT, signal_table.IgnoreHandler)
 
 	/* start signal handler routine */
 	srv.SignalTable.StartSignalHandle()

--- a/bfe_util/signal_table/register_signal.go
+++ b/bfe_util/signal_table/register_signal.go
@@ -29,5 +29,4 @@ func RegisterSignalHandlers(signalTable *SignalTable) {
 	signalTable.Register(syscall.SIGILL, IgnoreHandler)
 	signalTable.Register(syscall.SIGTRAP, IgnoreHandler)
 	signalTable.Register(syscall.SIGABRT, IgnoreHandler)
-	signalTable.Register(syscall.SIGSTKFLT, IgnoreHandler)
 }


### PR DESCRIPTION
signal SIGSTKFLT is unused in linux and  block build on MAC, remove it.

