### PR TITLE
remove_pprof_from_bfe

### DIFF
--- a/bfe.go
+++ b/bfe.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	_ "net/http/pprof"
 	"path"
 	"runtime"
 	"time"


### PR DESCRIPTION
net/http/pprof 服务，默认注册至http.DefaultServeMux，在bfe server中并不起作用。后面会将pprof迁移至monitor server中。