### PR TITLE
Add pprof for monitor server

### DIFF
--- a/bfe.go
+++ b/bfe.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	_ "net/http/pprof"
 	"path"
 	"runtime"
 	"time"

--- a/bfe_server/web_server.go
+++ b/bfe_server/web_server.go
@@ -19,6 +19,7 @@ package bfe_server
 import (
 	"github.com/baidu/go-lib/log"
 	"github.com/baidu/go-lib/web-monitor/web_monitor"
+	"net/http/pprof"
 )
 
 type BfeMonitor struct {
@@ -130,6 +131,17 @@ func (m *BfeMonitor) reloadHandlers() map[string]interface{} {
 	return handlers
 }
 
+// pprofHandlers holds all pprof handlers.
+func (m *BfeMonitor) pprofHandlers() map[string]interface{} {
+	handlers := map[string]interface{}{
+		"cmdline": pprof.Cmdline,
+		"profile": pprof.Profile,
+		"symbol": pprof.Symbol,
+		"trace": pprof.Trace,
+	}
+	return handlers
+}
+
 func (m *BfeMonitor) WebHandlersInit(srv *BfeServer) error {
 	// register handlers for monitor
 	err := web_monitor.RegisterHandlers(m.WebHandlers, web_monitor.WEB_HANDLE_MONITOR,
@@ -138,9 +150,16 @@ func (m *BfeMonitor) WebHandlersInit(srv *BfeServer) error {
 		return err
 	}
 
-	// register handlers for for reload
+	// register handlers for reload
 	err = web_monitor.RegisterHandlers(m.WebHandlers, web_monitor.WEB_HANDLE_RELOAD,
 		m.reloadHandlers())
+	if err != nil {
+		return err
+	}
+
+	// register handlers for pprof
+	err = web_monitor.RegisterHandlers(m.WebHandlers, web_monitor.WEB_HANDLE_PPROF,
+		m.pprofHandlers())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
monitor server支持pprof功能，联动go-lib库，https://github.com/baidu/go-lib/pull/3

功能使用方法：
```
$ curl http://127.0.0.1:8421/pprof
<html>
<body>
<p>pprof manual for bfe</p>
<p>version: </p>
<p>start_at: 2019-11-27 17:16:58</p>
<p><a href="/pprof/cmdline">cmdline</a></p>
<p><a href="/pprof/profile">profile</a></p>
<p><a href="/pprof/symbol">symbol</a></p>
<p><a href="/pprof/trace">trace</a></p>

$ curl http://127.0.0.1:8421/pprof/profile >cpu.txt

$ go tool pprof cpu.txt                                                   
...
(pprof) top 10
Showing nodes accounting for 10ms, 100% of 10ms total
      flat  flat%   sum%        cum   cum%
      10ms   100%   100%       10ms   100%  runtime.(*lfstack).pop
         0     0%   100%       10ms   100%  runtime.(*gcWork).tryGet
         0     0%   100%       10ms   100%  runtime.gcBgMarkWorker
         0     0%   100%       10ms   100%  runtime.gcBgMarkWorker.func2
         0     0%   100%       10ms   100%  runtime.gcDrain
         0     0%   100%       10ms   100%  runtime.systemstack
         0     0%   100%       10ms   100%  runtime.trygetfull
```

