### PR TITLE
string trim space 

### DIFF
--- a/bfe_server/register_modules.go
+++ b/bfe_server/register_modules.go
@@ -31,7 +31,7 @@ func (srv *BfeServer) RegisterModules(modules []string) error {
 	}
 
 	for _, moduleName := range modules {
-		moduleName = strings.Trim(moduleName, " ")
+		moduleName = strings.TrimSpace(moduleName)
 		if len(moduleName) == 0 {
 			continue
 		}


### PR DESCRIPTION
use strings.TrimSpace to remove all leading and trailing white space