### PR TITLE
fix: clusterBasic default value bug

### DIFF
--- a/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
+++ b/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
@@ -119,7 +119,7 @@ type ClusterConf struct {
 	ClusterBasic *ClusterBasicConf // basic conf for cluster
 }
 
-type ClusterToConf map[string]ClusterConf
+type ClusterToConf map[string]*ClusterConf
 
 // BfeClusterConf is conf of all bfe cluster.
 type BfeClusterConf struct {
@@ -435,7 +435,7 @@ func ClusterConfCheck(conf *ClusterConf) error {
 // ClusterToConfCheck check ClusterToConf.
 func ClusterToConfCheck(conf *ClusterToConf) error {
 	for clusterName, clusterConf := range *conf {
-		err := ClusterConfCheck(&clusterConf)
+		err := ClusterConfCheck(clusterConf)
 
 		if err != nil {
 			return fmt.Errorf("conf for %s:%s", clusterName, err.Error())

--- a/bfe_route/bfe_cluster/bfe_cluster.go
+++ b/bfe_route/bfe_cluster/bfe_cluster.go
@@ -53,7 +53,7 @@ func NewBfeCluster(name string) *BfeCluster {
 	return cluster
 }
 
-func (cluster *BfeCluster) BasicInit(clusterConf cluster_conf.ClusterConf) {
+func (cluster *BfeCluster) BasicInit(clusterConf *cluster_conf.ClusterConf) {
 	// set backendConf and checkConf
 	cluster.backendConf = clusterConf.BackendConf
 	cluster.CheckConf = clusterConf.CheckConf


### PR DESCRIPTION
配置文件bug，文档上说免配置部分参数，实际上代码bug，未做到

bug复现

参考文档：https://github.com/baidu/bfe/blob/develop/docs/zh_cn/example/route.md

其中`Step 3. 配置集群的基础信息 (conf/server_data_conf/cluster_conf.data) 配置集群cluster_demo_static和cluster_demo_dynamic健康检查的参数，其他均使用默认值`

按照文档配置，报错
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x715ac5]

goroutine 1 [running]:
github.com/baidu/bfe/bfe_route/bfe_cluster.(*BfeCluster).BasicInit(0xc00009e500, 0x0, 0xc00033d700, 0x0, 0x0)
        /bfe/bfe_route/bfe_cluster/bfe_cluster.go:65 +0x55
github.com/baidu/bfe/bfe_route.(*ClusterTable).BasicInit(0xc000390220, 0xc000341ec0, 0xc000096490)
        /bfe/bfe_route/cluster_table.go:71 +0x28c
github.com/baidu/bfe/bfe_route.(*ClusterTable).Init(0xc000390220, 0xc0000b5740, 0x27, 0x0, 0xc00038c540)
        /bfe/bfe_route/cluster_table.go:55 +0x9e
github.com/baidu/bfe/bfe_route.(*ServerDataConf).clusterTableLoad(0xc000341640, 0xc0000b5740, 0x27, 0xc0000b5590, 0x23)
        /bfe/bfe_route/server_data_conf.go:100 +0x47
```

