### PR TITLE
修复默认配置为nil的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output
 /**/*.log
 profile.out
 coverage.txt
+.idea/

--- a/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
+++ b/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
@@ -435,7 +435,6 @@ func ClusterConfCheck(conf *ClusterConf) error {
 func ClusterToConfCheck(conf *ClusterToConf) error {
 	for clusterName, clusterConf := range *conf {
 		err := ClusterConfCheck(clusterConf)
-
 		if err != nil {
 			return fmt.Errorf("conf for %s:%s", clusterName, err.Error())
 		}

--- a/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
+++ b/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
@@ -119,7 +119,7 @@ type ClusterConf struct {
 	ClusterBasic *ClusterBasicConf // basic conf for cluster
 }
 
-type ClusterToConf map[string]ClusterConf
+type ClusterToConf map[string]*ClusterConf
 
 // BfeClusterConf is conf of all bfe cluster.
 type BfeClusterConf struct {
@@ -392,7 +392,6 @@ func ClusterBasicConfCheck(conf *ClusterBasicConf) error {
 // ClusterConfCheck check ClusterConf.
 func ClusterConfCheck(conf *ClusterConf) error {
 	var err error
-
 	// check BackendConf
 	if conf.BackendConf == nil {
 		conf.BackendConf = &BackendBasic{}
@@ -435,12 +434,13 @@ func ClusterConfCheck(conf *ClusterConf) error {
 // ClusterToConfCheck check ClusterToConf.
 func ClusterToConfCheck(conf *ClusterToConf) error {
 	for clusterName, clusterConf := range *conf {
-		err := ClusterConfCheck(&clusterConf)
+		err := ClusterConfCheck(clusterConf)
 
 		if err != nil {
 			return fmt.Errorf("conf for %s:%s", clusterName, err.Error())
 		}
 	}
+
 	return nil
 }
 

--- a/bfe_route/bfe_cluster/bfe_cluster.go
+++ b/bfe_route/bfe_cluster/bfe_cluster.go
@@ -53,7 +53,7 @@ func NewBfeCluster(name string) *BfeCluster {
 	return cluster
 }
 
-func (cluster *BfeCluster) BasicInit(clusterConf cluster_conf.ClusterConf) {
+func (cluster *BfeCluster) BasicInit(clusterConf *cluster_conf.ClusterConf) {
 	// set backendConf and checkConf
 	cluster.backendConf = clusterConf.BackendConf
 	cluster.CheckConf = clusterConf.CheckConf


### PR DESCRIPTION
集群配置中如果不指定配置项，默认配置为nil