### PR TITLE
Add Condition primitive: req_host_suffix_in(suffix_list)

### DIFF
--- a/bfe_basic/condition/build.go
+++ b/bfe_basic/condition/build.go
@@ -172,6 +172,13 @@ func buildPrimitive(node *parser.CallExpr) (Condition, error) {
 			fetcher: &HostFetcher{},
 			matcher: NewRegMatcher(reg),
 		}, nil
+	case "req_host_suffix_in":
+		return &PrimitiveCond{
+			name:    node.Fun.Name,
+			node:    node,
+			fetcher: &HostFetcher{},
+			matcher: NewSuffixInMatcher(node.Args[0].Value, true),
+		}, nil
 	case "req_path_in":
 		return &PrimitiveCond{
 			name:    node.Fun.Name,

--- a/bfe_basic/condition/parser/semant.go
+++ b/bfe_basic/condition/parser/semant.go
@@ -31,6 +31,7 @@ var funcProtos = map[string][]Token{
 	"req_host_in":                {STRING},
 	"req_host_regmatch":          {STRING},
 	"req_host_tag_in":            {STRING},
+	"req_host_suffix_in":         {STRING},
 	"req_path_in":                {STRING, BOOL},
 	"req_path_prefix_in":         {STRING, BOOL},
 	"req_path_suffix_in":         {STRING, BOOL},


### PR DESCRIPTION
Condition primitive: req_host_suffix_in #475
Description:
Add Condition primitive: req_host_suffix_in(suffix_list)
Example:
check the request host is a subdomain of example.com or example.org
req_host_suffix_in(".example.com|.example.org")