### PR TITLE
Fix mod_markdown license header

### DIFF
--- a/bfe_modules/mod_markdown/mod_markdown_test.go
+++ b/bfe_modules/mod_markdown/mod_markdown_test.go
@@ -1,3 +1,18 @@
+// Copyright 2021 The BFE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package mod_markdown
 
 import (


### PR DESCRIPTION
Repair `bfe_modules/mod_markdown/mod_markdown_test.go` license header declaration according [Apache License2.0](http://www.apache.org/licenses/LICENSE-2.0)